### PR TITLE
fix: Use ExitCode instead of ExitStatus when executing commands

### DIFF
--- a/src/main/pascal/PasBuild.Utils.pas
+++ b/src/main/pascal/PasBuild.Utils.pas
@@ -249,7 +249,7 @@ begin
         AProcess.WaitOnExit;
       end;
 
-      Result := AProcess.ExitStatus;
+      Result := AProcess.ExitCode;
     except
       on E: Exception do
       begin
@@ -287,7 +287,7 @@ begin
       AProcess.Execute;
       OutputList.LoadFromStream(AProcess.Output);
       AOutput := OutputList.Text;
-      Result := AProcess.ExitStatus;
+      Result := AProcess.ExitCode;
     except
       on E: Exception do
       begin
@@ -368,7 +368,7 @@ begin
         end;
       end;
 
-      Result := AProcess.ExitStatus;
+      Result := AProcess.ExitCode;
     except
       on E: Exception do
       begin


### PR DESCRIPTION
[On Unix this makes a difference](https://docs.freepascal.org/docs-html/current/fcl/process/tprocess.exitcode.html). The actual exit code is returned in ExitCode. Without this change the exit code of `pasbuild` might differ from the exit code of the compile command. For instance, the following shows the output of a failed compilation on my system without this change (the example shows a nushell output, but this is not important):

```
% ../PasBuild/target/pasbuild compile | complete
╭───────────┬───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ stdout    │ [INFO] PasBuild 1.3.0                                                                             │
│           │ [INFO] Copyright (c) 2025 by Graeme Geldenhuys                                                    │
│           │                                                                                                   │
│           │ [INFO] Executing goal: process-resources                                                          │
│           │ [INFO] No resources directory found (src/main/resources), skipping                                │
│           │ [INFO] Executing goal: compile                                                                    │
│           │ [INFO] Compiling project...                                                                       │
│           │ [INFO] Found 2 source file(s)                                                                     │
│           │                                                                                                   │
│ stderr    │ [ERROR] Main.pas(21,18) Error: identifier idents no member "RegisterInterceptor"                  │
│           │ [ERROR] Main.pas(29) Fatal: There were 1 errors compiling module, stopping                        │
│           │ [ERROR] Fatal: Compilation aborted                                                                │
│           │ [ERROR] Error: /usr/bin/ppcx64 returned an error exitcode                                         │
│           │ [ERROR] Build failed with exit code: 256 (see target/pasbuild-status/compile/fpc.log for details) │
│           │ [ERROR] Goal failed: compile                                                                      │
│           │                                                                                                   │
│ exit_code │ 0                                                                                                 │
╰───────────┴───────────────────────────────────────────────────────────────────────────────────────────────────╯
``` 
Note that the exit_code of `pasbuild` is 0 (last line) although the build failed (as can be seen in the `stderr` output). The reason for this is that executing the `fpc` compile command does indeed return an **ExitCode** of 1, but an **ExitStatus** of 256. The latter is then returned eventually by `pasbuild` (but since the exit code is restricted to 1 byte [at least on linux, afaik] and the lower 8 bits of 256 are 0 this causes pasbuild's exit code to be zero).

With this proposed change the correct exit code is returned:
```
% ../PasBuild/target/pasbuild compile | complete
╭───────────┬─────────────────────────────────────────────────────────────────────────────────────────────────╮
│ stdout    │ [INFO] PasBuild 1.3.0                                                                           │
│           │ [INFO] Copyright (c) 2025 by Graeme Geldenhuys                                                  │
│           │                                                                                                 │
│           │ [INFO] Executing goal: process-resources                                                        │
│           │ [INFO] No resources directory found (src/main/resources), skipping                              │
│           │ [INFO] Executing goal: compile                                                                  │
│           │ [INFO] Compiling project...                                                                     │
│           │ [INFO] Found 2 source file(s)                                                                   │
│           │                                                                                                 │
│ stderr    │ [ERROR] Main.pas(21,18) Error: identifier idents no member "RegisterInterceptor"                │
│           │ [ERROR] Main.pas(29) Fatal: There were 1 errors compiling module, stopping                      │
│           │ [ERROR] Fatal: Compilation aborted                                                              │
│           │ [ERROR] Error: /usr/bin/ppcx64 returned an error exitcode                                       │
│           │ [ERROR] Build failed with exit code: 1 (see target/pasbuild-status/compile/fpc.log for details) │
│           │ [ERROR] Goal failed: compile                                                                    │
│           │                                                                                                 │
│ exit_code │ 1                                                                                               │
╰───────────┴─────────────────────────────────────────────────────────────────────────────────────────────────╯
```