### PR TITLE
Added Option to create an lpk for libraries

### DIFF
--- a/src/main/pascal/PasBuild.Bootstrap.pas
+++ b/src/main/pascal/PasBuild.Bootstrap.pas
@@ -28,12 +28,13 @@ type
       const AOutputPath: string;
       AActiveDefines: TStringList
     ): Boolean;
-  private
+  protected
     class function DiscoverUnits(
       const ABasePath: string;
       AUnitPaths: TConditionalPathList;
       AManualMode: Boolean;
-      AActiveDefines: TStringList
+      AActiveDefines: TStringList;
+      AUnitNameOnly: Boolean
     ): TStringList;
     class function ParseUnitName(const AFilePath: string): string;
   end;
@@ -47,11 +48,13 @@ var
   F: TextFile;
   Line: string;
   UnitPos: Integer;
+  UnitKeyFound: Boolean;
   InBraceComment: Boolean;
   InParenComment: Boolean;
   CommentEndPos: Integer;
 begin
   Result := '';
+  UnitKeyFound := False;
 
   if not FileExists(AFilePath) then
     Exit;
@@ -147,17 +150,31 @@ begin
           Continue;
 
         // Look for "unit <name>;"
-        if AnsiStartsStr('unit ', LowerCase(Line)) then
+        if UnitKeyFound or AnsiStartsStr('unit', LowerCase(Line)) then
         begin
-          UnitPos := Pos('unit ', LowerCase(Line));
-          if UnitPos > 0 then
+          UnitPos := Pos('unit', LowerCase(Line));
+          if (UnitPos > 0) or UnitKeyFound then
           begin
-            Delete(Line, 1, UnitPos + 4);  // Remove "unit "
+            if not UnitKeyFound then
+              Delete(Line, 1, UnitPos + 3);  // Remove "unit"
+            if (Length(Trim(Line)) = 0) then
+            begin
+              // can be "unit\n" check on the next line
+              UnitKeyFound := True;
+              Continue;
+            end;
+
+            if not UnitKeyFound and (Line[1] <> ' ') then
+              Continue;
+
             Line := Trim(Line);
 
             // Remove trailing semicolon
             if AnsiEndsStr(';', Line) then
+            begin
               Delete(Line, Length(Line), 1);
+              UnitKeyFound:=False;
+            end;
 
             Result := Trim(Line);
           end;
@@ -176,7 +193,8 @@ class function TBootstrapGenerator.DiscoverUnits(
   const ABasePath: string;
   AUnitPaths: TConditionalPathList;
   AManualMode: Boolean;
-  AActiveDefines: TStringList
+  AActiveDefines: TStringList;
+  AUnitNameOnly: Boolean
 ): TStringList;
 var
   AllDirs, Units: TStringList;
@@ -223,10 +241,16 @@ begin
         try
           repeat
             UnitFile := IncludeTrailingPathDelimiter(Dir) + SearchRec.Name;
-            DiscoveredUnit := ParseUnitName(UnitFile);
+            if AUnitNameOnly then
+            begin
+              DiscoveredUnit := ParseUnitName(UnitFile);
 
-            if DiscoveredUnit <> '' then
-              Result.Add(DiscoveredUnit);
+              if DiscoveredUnit <> '' then
+                Result.Add(DiscoveredUnit);
+            end
+            else begin
+              Result.Add(UnitFile);
+            end;
           until FindNext(SearchRec) <> 0;
         finally
           FindClose(SearchRec);
@@ -261,7 +285,8 @@ begin
     BasePath,
     AConfig.BuildConfig.UnitPaths,
     AConfig.BuildConfig.ManualUnitPaths,
-    AActiveDefines
+    AActiveDefines,
+    True
   );
 
   try

--- a/src/main/pascal/PasBuild.CLI.pas
+++ b/src/main/pascal/PasBuild.CLI.pas
@@ -23,7 +23,7 @@ const
 
 type
   { Valid build goals }
-  TBuildGoal = (bgUnknown, bgClean, bgProcessResources, bgCompile, bgProcessTestResources, bgTestCompile, bgTest, bgPackage, bgSourcePackage, bgInstall, bgDependencyTree, bgResolve, bgInit, bgHelp, bgVersion, bgLicense);
+  TBuildGoal = (bgUnknown, bgClean, bgProcessResources, bgCompile, bgProcessTestResources, bgTestCompile, bgTest, bgPackage, bgSourcePackage, bgLazarusPackage, bgInstall, bgDependencyTree, bgResolve, bgInit, bgHelp, bgVersion, bgLicense);
 
   { Parsed command-line arguments }
   TCommandLineArgs = record
@@ -262,6 +262,7 @@ begin
   WriteLn('  test                    Run tests (runs: compile -> process-test-resources -> test-compile -> test)');
   WriteLn('  package                 Create release archive (runs: clean -> compile -> package)');
   WriteLn('  source-package          Create source archive with src/, docs, and configured files');
+  WriteLn('  lazarus-package         Create a *.lpk in the target/lazpkg folder.');
   WriteLn('  install                 Install compiled units to local repository (~/.pasbuild/repository/)');
   WriteLn('  dependency-tree         Show project dependency tree (no compilation)');
   WriteLn('  resolve                 Output resolved build configuration as JSON (no compilation)');

--- a/src/main/pascal/PasBuild.CLI.pas
+++ b/src/main/pascal/PasBuild.CLI.pas
@@ -54,69 +54,62 @@ type
 implementation
 
 uses
-  PasBuild.Utils;
+  PasBuild.Utils, TypInfo;
 
 { TArgumentParser }
 
 class function TArgumentParser.GoalFromString(const AGoalStr: string): TBuildGoal;
 var
   GoalLower: string;
+  GoalEnumName: string;
 begin
   GoalLower := LowerCase(AGoalStr);
+  GoalEnumName := 'bg'+StringReplace(GoalLower, '-', '', [rfReplaceAll]);
+  if GoalLower = '-h' then
+    GoalLower := '--help';
+  try
+    Result := TBuildGoal(GetEnumValue(TypeInfo(TBuildGoal), GoalEnumName));
+    if Ord(Result) = -1 then Result := bgUnknown;
+  except
+    Result := bgUnknown;
+  end;
 
-  if GoalLower = 'clean' then
-    Result := bgClean
-  else if GoalLower = 'process-resources' then
-    Result := bgProcessResources
-  else if GoalLower = 'compile' then
-    Result := bgCompile
-  else if GoalLower = 'process-test-resources' then
-    Result := bgProcessTestResources
-  else if GoalLower = 'test-compile' then
-    Result := bgTestCompile
-  else if GoalLower = 'test' then
-    Result := bgTest
-  else if GoalLower = 'package' then
-    Result := bgPackage
-  else if GoalLower = 'source-package' then
-    Result := bgSourcePackage
-  else if GoalLower = 'install' then
-    Result := bgInstall
-  else if GoalLower = 'dependency-tree' then
-    Result := bgDependencyTree
-  else if GoalLower = 'resolve' then
-    Result := bgResolve
-  else if GoalLower = 'init' then
-    Result := bgInit
-  else if (GoalLower = '--help') or (GoalLower = '-h') then
-    Result := bgHelp
-  else if GoalLower = '--version' then
-    Result := bgVersion
-  else if GoalLower = '--license' then
-    Result := bgLicense
-  else
+  if (Result in [bgHelp, bgVersion, bgLicense])
+  and (Copy(GoalLower, 1, 2) <> '--') then
     Result := bgUnknown;
 end;
 
 class function TArgumentParser.GoalToString(AGoal: TBuildGoal): string;
+var
+  i: Integer;
 begin
-  case AGoal of
-    bgClean: Result := 'clean';
-    bgProcessResources: Result := 'process-resources';
-    bgCompile: Result := 'compile';
-    bgProcessTestResources: Result := 'process-test-resources';
-    bgTestCompile: Result := 'test-compile';
-    bgTest: Result := 'test';
-    bgPackage: Result := 'package';
-    bgSourcePackage: Result := 'source-package';
-    bgInstall: Result := 'install';
-    bgDependencyTree: Result := 'dependency-tree';
-    bgResolve: Result := 'resolve';
-    bgInit: Result := 'init';
-    bgHelp: Result := '--help';
-    bgVersion: Result := '--version';
-    bgLicense: Result := '--license';
-    else Result := 'unknown';
+  try
+    // get Enum name e.g. bgProcessResources and copy just 'ProcessResources';
+    Result := Copy(GetEnumName(TypeInfo(TBuildGoal), Ord(AGoal)), 3, Maxint);
+
+    // set 'P' to 'p' for 'processResources' example
+    Result[1] := LowerCase(Result[1]); // set first letter lowercase
+
+    i := 2; // start on second letter
+    while i <= Length(Result) do
+    begin
+      // look for capitol letters which indicate a hyphen
+      if Result[i] <> LowerCase(Result[i]) then
+      begin
+        // insert hyphen
+        Result[i] := LowerCase(Result[i]);
+        Insert('-', Result, i);
+        Inc(i);
+      end;
+      Inc(i);
+    end;
+
+    // now some special cases
+    case Result of
+      'help', 'version', 'license': Result := '--' + Result;
+    end;
+  except
+    Result := 'unknown';
   end;
 end;
 

--- a/src/main/pascal/PasBuild.Command.LazarusPackage.pas
+++ b/src/main/pascal/PasBuild.Command.LazarusPackage.pas
@@ -1,0 +1,128 @@
+
+{
+  This file is part of PasBuild.
+
+  Copyright (c) 2025 Graeme Geldenhuys <graemeg@gmail.com>
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  See LICENSE file in the project root for full license terms.
+}
+unit PasBuild.Command.LazarusPackage;
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils,
+  PasBuild.Types,
+  PasBuild.Command,
+  PasBuild.Utils,
+  PasBuild.LazarusPackage;
+
+type
+  { lazarus-package command - builds a lpk and pas }
+
+  { TLazarusPackageCommand }
+
+  TLazarusPackageCommand = class(TBuildCommand)
+  protected
+    function GetName: string; override;
+  public
+    function Execute: Integer; override;
+    function GetDependencies: TBuildCommandList; override;
+  end;
+
+implementation
+
+uses
+  PasBuild.Command.ProcessResources;
+
+
+{ TLazarusPackageCommand }
+
+function TLazarusPackageCommand.GetName: string;
+begin
+  Result := 'lazarus-package';
+end;
+
+function TLazarusPackageCommand.Execute: Integer;
+var
+  OutputDir, UnitsDir, ProfileId: String;
+  ActiveDefines: TStringList;
+  Profile: TProfile;
+begin
+  Result := 0;
+
+  TUtils.LogInfo('Building Lazarus Package...');
+  if Config.BuildConfig.ProjectType <> ptLibrary then
+  begin
+    TUtils.LogError('Goal lazarus-package invalid for project '  + Config.Name);
+    Result := 0; // because perhaps it's part of a group of modules.
+    Exit;
+  end;
+
+  // Verify directory layout
+  if not TUtils.VerifyDirectoryLayout('.', Config.BuildConfig.SourceDirectory) then
+  begin
+    Result := 1;
+    Exit;
+  end;
+
+  // Create output directories first (needed for bootstrap generation)
+  OutputDir := TUtils.NormalizePath(Config.BuildConfig.OutputDirectory);
+  UnitsDir := OutputDir + DirectorySeparator + 'units';
+
+  if not ForceDirectories(OutputDir) then
+  begin
+    TUtils.LogError('Failed to create output directory: ' + OutputDir);
+    Result := 1;
+    Exit;
+  end;
+
+  if not ForceDirectories(UnitsDir) then
+  begin
+    TUtils.LogError('Failed to create units directory: ' + UnitsDir);
+    Result := 1;
+    Exit;
+  end;
+
+  // Collect active defines (same logic as BuildCompilerCommand)
+  ActiveDefines := TStringList.Create;
+  try
+    ActiveDefines.Duplicates := dupIgnore;
+    ActiveDefines.Sorted := True;
+    ActiveDefines.AddStrings(Config.BuildConfig.Defines);
+
+    // Add defines from each active profile in order
+    for ProfileId in ProfileIds do
+    begin
+      Profile := Config.Profiles.FindById(ProfileId);
+      if Assigned(Profile) then
+        ActiveDefines.AddStrings(Profile.Defines);
+    end;
+    if not TLazarusPackageGenerator.GenerateLazarusPackage(Config, ActiveDefines) then
+    begin
+      TUtils.LogError('Failed to generate lazarus package');
+      Result := 1;
+      Exit;
+    end;
+  finally
+    ActiveDefines.Free;
+  end;
+end;
+
+function TLazarusPackageCommand.GetDependencies: TBuildCommandList;
+begin
+  Result := TBuildCommandList.Create(False);
+  try
+    //
+    //Result.Add(TProcessResourcesCommand.Create(Config, Config.ResourcesConfig, Config.BuildConfig.OutputDirectory));
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+
+end.
+

--- a/src/main/pascal/PasBuild.Command.Reactor.pas
+++ b/src/main/pascal/PasBuild.Command.Reactor.pas
@@ -23,6 +23,7 @@ uses
   PasBuild.Command.Test,
   PasBuild.Command.Package,
   PasBuild.Command.Install,
+  PasBuild.Command.LazarusPackage,
   PasBuild.Utils;
 
 type
@@ -265,6 +266,9 @@ begin
 
           'compile':
             ModuleCommand := TCompileCommand.Create(ModuleConfig, FProfileIds);
+
+          'lazarus-package':
+            ModuleCommand := TLazarusPackageCommand.Create(ModuleConfig, FProfileIds);
 
           'test-compile':
             ModuleCommand := TTestCompileCommand.Create(ModuleConfig, FProfileIds);

--- a/src/main/pascal/PasBuild.LazarusPackage.pas
+++ b/src/main/pascal/PasBuild.LazarusPackage.pas
@@ -1,0 +1,327 @@
+unit PasBuild.LazarusPackage;
+interface
+
+uses
+  Classes, SysUtils, DOM, XMLWrite,
+  PasBuild.Types,
+  PasBuild.Utils,
+  PasBuild.Bootstrap;
+
+type
+  { Lazarus package generator for library projects }
+
+  { TLazarusPackageGenerator }
+
+  TLazarusPackageGenerator = class(TBootstrapGenerator)
+  public
+    class function GenerateLazarusPackage(AConfig: TProjectConfig;
+      AActiveDefines: TStringList): Boolean;
+  private
+    class function CreatePackageDOM(AConfig: TProjectConfig; AUnits,
+      AActiveDefines: TStringList): TXMLDocument;
+    class function GetOutputPackageDirectory(AConfig: TProjectConfig): String;
+    class function GetOutputUnitDirectory(AConfig: TProjectConfig; RelativePath: Boolean): String;
+    class function CreateSearchPathNode(AConfig: TProjectConfig; Doc: TXMLDocument; AUnits, AActiveDefines: TStringList): TDOMElement;
+    class function CreateFilesNode(AConfig: TProjectConfig; Doc: TXMLDocument; AUnits: TStringList): TDOMElement;
+    class function CreateRequiredPackagesNode(AConfig: TProjectConfig; Doc: TXMLDocument): TDOMElement;
+
+  end;
+
+implementation
+
+{ TLazarusPackageGenerator }
+
+class function TLazarusPackageGenerator.GenerateLazarusPackage(
+  AConfig: TProjectConfig; AActiveDefines: TStringList): Boolean;
+var
+  Units: TStringList;
+  BasePath, PackageName, lPackageXMLFile: string;
+  PackageXML: TXMLDocument;
+  lExisting: TStringStream = nil;
+  lNewFile: TStringStream;
+begin
+  Result := False;
+
+  TUtils.LogInfo('Generating Lazarus package file for library...');
+
+  // Discover all units
+  BasePath := TUtils.NormalizePath(AConfig.BuildConfig.SourceDirectory);
+  Units := DiscoverUnits(
+    BasePath,
+    AConfig.BuildConfig.UnitPaths,
+    AConfig.BuildConfig.ManualUnitPaths,
+    AActiveDefines,
+    False
+  );
+
+  try
+    if Units.Count = 0 then
+    begin
+      TUtils.LogWarning('No units found for Lazarus Package');
+      Exit;
+    end;
+
+    PackageName := StringReplace(AConfig.Name, '-','_', [rfReplaceAll]);
+
+    TUtils.LogInfo('Discovered ' + IntToStr(Units.Count) + ' units');
+
+    // Write to file
+    lPackageXMLFile := IncludeTrailingPathDelimiter(GetOutputPackageDirectory(AConfig))+PackageName+'.lpk';
+
+    ForceDirectories(ExtractFilePath(lPackageXMLFile));
+
+    try
+      try
+
+        PackageXML := CreatePackageDOM(AConfig, Units, AActiveDefines);
+        lNewFile := TStringStream.Create;
+        WriteXMLFile(PackageXML, lNewFile);
+        while true do  // lets us use break
+        begin
+          if FileExists(lPackageXMLFile) then
+          begin
+            lExisting := TStringStream.Create;
+            lExisting.LoadFromFile(lPackageXMLFile);
+            // prevent overwriting an identical file
+            if lNewFile.DataString = lExisting.DataString then
+              Break; //
+          end;
+          lNewFile.SaveToFile(lPackageXMLFile);
+          Break;
+        end;
+
+        TUtils.LogInfo('Package File (.lpk) Generated: ' + ChangeFileExt(lPackageXMLFile, '.lpk'));
+      finally
+        FreeAndNil(lNewFile);
+        FreeAndNil(lExisting);
+        FreeAndNil(PackageXML);
+      end;
+
+      Result := True;
+    except
+      on E: Exception do
+      begin
+        TUtils.LogError('Failed to write lazarus package files: ' + E.Message);
+        Result := False;
+      end;
+    end;
+
+  finally
+    Units.Free;
+  end;
+end;
+
+class function TLazarusPackageGenerator.CreatePackageDOM(
+  AConfig: TProjectConfig; AUnits, AActiveDefines: TStringList): TXMLDocument;
+var
+  RootNode: TDOMNode;
+  NameNode, PackageNode, CompilerOptionsNode, VersionNode,
+  UsageOptionsNode, UnitPathNode,
+  PublishOptionsNode, UseFileFiltersNode: TDOMElement;
+begin
+  Result := TXMLDocument.Create;
+  RootNode := Result.AppendChild(Result.CreateElement('CONFIG'));
+  PackageNode := RootNode.AppendChild(Result.CreateElement('Package')) as TDOMElement;
+    PackageNode.AttribStrings['Version'] := '5';
+    NameNode := PackageNode.AppendChild(Result.CreateElement('Name')) as TDOMElement;
+      NameNode.AttribStrings['Value'] := UnicodeString(StringReplace(AConfig.Name, '-', '_', [rfReplaceAll]));
+
+    CompilerOptionsNode := PackageNode.AppendChild(Result.CreateElement('CompilerOptions')) as TDOMElement;
+      VersionNode := CompilerOptionsNode.AppendChild(Result.CreateElement('Version')) as TDOMElement;
+        VersionNode.AttribStrings['Value'] := '11';
+
+       // Collects paths of used units and adds the paths and include files
+      CompilerOptionsNode.AppendChild(CreateSearchPathNode(AConfig, Result, AUnits, AActiveDefines));
+
+    // Add File list
+    {FilesNode := }PackageNode.AppendChild(CreateFilesNode(AConfig, Result, AUnits));
+    // Add Dependancies
+    {RequirePkgsNode := }PackageNode.AppendChild(CreateRequiredPackagesNode(AConfig, Result));
+
+    UsageOptionsNode := PackageNode.AppendChild(Result.CreateElement('UsageOptions')) as TDOMElement;
+      {IncludePathNode := UsageOptionsNode.AppendChild(Result.CreateElement('IncludePath')) as TDOMElement;
+        IncludePathNode.Attributes['Value'] := } // this is for other libraries and projects to search. not for compilation
+      UnitPathNode := UsageOptionsNode.AppendChild(Result.CreateElement('UnitPath')) as TDOMElement;
+        UnitPathNode.AttribStrings['Value'] := '$(PkgOutDir)';
+
+    PublishOptionsNode := PackageNode.AppendChild(Result.CreateElement('PublishOptions')) as TDOMElement;
+      VersionNode := PublishOptionsNode.AppendChild(Result.CreateElement('Version')) as TDOMElement;
+        VersionNode.AttribStrings['Value'] := '2';
+      UseFileFiltersNode := PublishOptionsNode.AppendChild(Result.CreateElement('UseFileFilters')) as TDOMElement;
+        UseFileFiltersNode.AttribStrings['Value'] := 'True';
+
+    // the end
+
+end;
+
+class function TLazarusPackageGenerator.GetOutputPackageDirectory(
+  AConfig: TProjectConfig): String;
+var
+  OutputDir: String;
+begin
+  OutputDir := TUtils.NormalizePath(AConfig.BuildConfig.OutputDirectory);
+  Result := OutputDir + DirectorySeparator + 'lazpkg';
+end;
+
+class function TLazarusPackageGenerator.GetOutputUnitDirectory(
+  AConfig: TProjectConfig; RelativePath: Boolean): String;
+var
+  OutputDir, PackageDir, lPrefix: String;
+begin
+  if RelativePath then
+    lPrefix := GetCurrentDir
+  else
+    lPrefix := '';
+  OutputDir := lPrefix + IncludeTrailingPathDelimiter(TUtils.NormalizePath(AConfig.BuildConfig.OutputDirectory));
+  PackageDir := lPrefix + IncludeTrailingPathDelimiter(GetOutputPackageDirectory(AConfig));
+  Result := OutputDir + 'units';
+  if RelativePath then
+    Result := ExtractRelativePath(PackageDir, Result);
+end;
+
+class function TLazarusPackageGenerator.CreateSearchPathNode(
+  AConfig: TProjectConfig; Doc: TXMLDocument; AUnits,
+  AActiveDefines: TStringList): TDOMElement;
+var
+  UnitOutputDirectoryNode, OtherUnitFilesNode, IncludeFilesNode: TDOMElement;
+  lPaths, lIncludeFiles, lIncludePaths, IncludePaths: TStringList;
+  lFile, lPackageDir, BasePath, lRelativePath: String;
+  i: Integer;
+begin
+  // Result is <SearchPaths> node
+  Result := Doc.CreateElement('SearchPaths');
+  UnitOutputDirectoryNode := Result.AppendChild(Doc.CreateElement('UnitOutputDirectory')) as TDOMElement;
+  UnitOutputDirectoryNode.AttribStrings['Value'] := UnicodeString(GetOutputUnitDirectory(AConfig, True));
+
+  try
+    lPaths := TStringList.Create;
+    lPaths.Sorted:=True;
+    lPaths.Duplicates:=TDuplicates.dupIgnore;
+    lPaths.Delimiter:=';';
+    lPackageDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+       + IncludeTrailingPathDelimiter(GetOutputPackageDirectory(AConfig));
+
+
+
+
+    for lFile in AUnits do
+    begin
+      lPaths.Add(ExcludeTrailingPathDelimiter(ExtractRelativePath(lPackageDir, IncludeTrailingPathDelimiter(GetCurrentDir) + IncludeTrailingPathDelimiter(ExtractFileDir(lFile)))));
+    end;
+    try
+      lIncludePaths := TStringList.Create;
+      lIncludePaths.Sorted:=True;
+      lIncludePaths.Duplicates:=TDuplicates.dupIgnore;
+      lIncludePaths.Delimiter:=';';
+
+      BasePath := TUtils.NormalizePath(AConfig.BuildConfig.SourceDirectory);
+
+
+      IncludePaths := nil;
+
+      if AConfig.BuildConfig.IncludePaths.Count > 0 then
+          IncludePaths := TUtils.ScanForIncludePathsFiltered(
+            BasePath,
+            AConfig.BuildConfig.IncludePaths,
+            AActiveDefines
+          );
+
+      if Assigned(IncludePaths) then
+      begin
+        for i := 0 to IncludePaths.Count-1 do
+        begin
+
+          lFile := IncludePaths[i];
+
+          lRelativePath := ExtractRelativePath(
+            lPackageDir,
+            IncludeTrailingPathDelimiter(GetCurrentDir) + IncludeTrailingPathDelimiter(ExtractFileDir(lFile)));
+          lIncludePaths.Add(ExcludeTrailingPathDelimiter(lRelativePath));
+        end;
+
+        // no need for duplicate paths if it's already on the other unit files
+        for i := lIncludePaths.Count-1 downto 0 do
+        begin
+          if lPaths.Contains(lIncludePaths.Strings[i]) then
+            lIncludePaths.Delete(i);
+        end;
+
+        if lIncludePaths.Count > 0 then
+        begin
+          IncludeFilesNode := Result.AppendChild(Doc.CreateElement('IncludeFiles')) as TDOMElement;
+          IncludeFilesNode.AttribStrings['Value'] := UnicodeString(lIncludePaths.DelimitedText);
+        end;
+      end;   // if Assigned(IncludePaths);
+
+      OtherUnitFilesNode := Result.AppendChild(Doc.CreateElement('OtherUnitFiles')) as TDOMElement;
+      OtherUnitFilesNode.AttribStrings['Value'] := UnicodeString(lPaths.DelimitedText);
+
+    finally
+      lIncludePaths.Free;
+      IncludePaths.Free;
+    end;
+
+  finally
+    lPaths.Free;
+  end;
+end;
+
+class function TLazarusPackageGenerator.CreateFilesNode(
+  AConfig: TProjectConfig; Doc: TXMLDocument; AUnits: TStringList): TDOMElement;
+var
+  ItemNode, FileNode, UnitNameNode, TypeNode: TDOMElement;
+  lPackagePath, lFile, lExt, lType, lPrefix, lUnitName: String;
+begin
+  lPackagePath := IncludeTrailingPathDelimiter(GetOutputPackageDirectory(AConfig));
+  Result := Doc.CreateElement('Files') as TDOMElement;
+
+  lPrefix := IncludeTrailingPathDelimiter(GetCurrentDir);
+
+  for lFile in AUnits do
+  begin
+    lUnitName := ParseUnitName(lFile);
+    if lUnitName = '' then
+    begin
+      TUtils.LogWarning('Skipped '+ lFile +  ' because unit name not found.');
+      Continue;
+    end;
+    ItemNode := Result.AppendChild(Doc.CreateElement('Item')) as TDOMElement;
+    FileNode := ItemNode.AppendChild(Doc.CreateElement('Filename')) as TDOMElement;
+    FileNode.AttribStrings['Value'] := UnicodeString(ExtractRelativePath(lPrefix+lPackagePath, lPrefix+lFile));
+
+    lExt := lowercase(ExtractFileExt(lFile));
+    case lExt of
+      '.pas', '.lpr', '.pp' : lType := '';
+      '.inc', '.include': lType := 'Include';
+      '.txt': lType := 'Text';
+      '.md': lType := 'Text'; // Markdown?
+    else
+      lType := 'Binary'; // can also include text. the ide doesn't seem to care
+    end;
+    if lType = '' then // unit
+    begin
+      UnitNameNode := ItemNode.AppendChild(Doc.CreateElement('UnitName')) as TDOMElement;
+      UnitNameNode.AttribStrings['Value'] := UnicodeString(lUnitName);
+    end
+    else begin
+      TypeNode := ItemNode.AppendChild(Doc.CreateElement('Type')) as TDOMElement;
+      TypeNode.AttribStrings['Value'] := UnicodeString(lType);
+    end;
+
+  end;
+
+end;
+
+class function TLazarusPackageGenerator.CreateRequiredPackagesNode(
+  AConfig: TProjectConfig; Doc: TXMLDocument): TDOMElement;
+var
+  ItemNode, PackageNameNode: TDOMElement;
+begin
+  // This is basically empty but it should probably be expanded
+  Result := Doc.CreateElement('RequiredPkgs') as TDOMElement;
+  ItemNode := Result.AppendChild(Doc.CreateElement('Item')) as TDOMElement;
+  PackageNameNode := ItemNode.AppendChild(Doc.CreateElement('PackageName')) as TDOMElement;
+  PackageNameNode.AttribStrings['Value'] := 'FCL';
+end;
+
+end.

--- a/src/main/pascal/PasBuild.pas
+++ b/src/main/pascal/PasBuild.pas
@@ -38,7 +38,7 @@ uses
   PasBuild.ModuleDiscovery,
   PasBuild.Repository,
   PasBuild.Dependencies,
-  PasBuild.Utils;
+  PasBuild.Utils, PasBuild.LazarusPackage, PasBuild.Command.LazarusPackage;
 
 var
   Args: TCommandLineArgs;
@@ -215,6 +215,9 @@ begin
             bgCompile:
               Command := TReactorCommand.Create(Config, Args.ProfileIds, Registry, 'compile', Args.SelectedModule);
 
+            bgLazarusPackage:
+              Command := TReactorCommand.Create(Config, Args.ProfileIds, Registry, 'lazarus-package', Args.SelectedModule);
+
             bgTestCompile:
               Command := TReactorCommand.Create(Config, Args.ProfileIds, Registry, 'test-compile', Args.SelectedModule);
 
@@ -270,6 +273,9 @@ begin
 
           bgCompile:
             Command := TCompileCommand.Create(Config, Args.ProfileIds);
+
+          bgLazarusPackage:
+            Command := TLazarusPackageCommand.Create(Config, Args.ProfileIds);
 
           bgProcessTestResources:
             Command := TProcessTestResourcesCommand.Create(Config, Config.TestResourcesConfig, Config.BuildConfig.OutputDirectory);


### PR DESCRIPTION
First I changed the TArgumentParser.GoalToString/ToGoal code to not need updating for new goals. This was not really needed so, sorry for that. 

Added an option 'lazarus-package' as a goal. It builds an lpk if a project is a 'library' type. + 2 new units to implement that.
I based then on the Compile command and removed what I didn't need. 

Specifically I did this for the fpgui_framework.lpk file. which I later found in _template. But this could be useful too for anything. Lazarus is more than happy to generate the pas file that goes with the lpk. 

Let me know if this fits or there's something you'd like changed.