### PR TITLE
Added text color to console output

### DIFF
--- a/src/main/pascal/PasBuild.CLI.pas
+++ b/src/main/pascal/PasBuild.CLI.pas
@@ -231,7 +231,7 @@ begin
     // Deprecated alias
     else if (Arg = '--fpc') then
     begin
-      WriteLn('[WARN] --fpc is deprecated; use --compiler instead');
+      TUtils.LogWarning('--fpc is deprecated; use --compiler instead');
       Inc(I);
       if I > ParamCount then
       begin

--- a/src/main/pascal/PasBuild.Utils.Console.pas
+++ b/src/main/pascal/PasBuild.Utils.Console.pas
@@ -1,7 +1,7 @@
 {
   This file is part of PasBuild.
 
-  Copyright (c) 2025 Graeme Geldenhuys <graemeg@gmail.com>
+  Copyright (c) 2026 Graeme Geldenhuys <graemeg@gmail.com>
 
   SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/main/pascal/PasBuild.Utils.pas
+++ b/src/main/pascal/PasBuild.Utils.pas
@@ -554,14 +554,13 @@ var
 begin
   case ATag of
     '[INFO]'    : Color := scBlue;
-    '[WARN]'    : Color := scYellow;
     '[WARNING]' : Color := scYellow;
     '[ERROR]'   : Color := scRed;
   else
     Color := scWhite;
   end;
   WriteColor(Color, ATag+' ', LogTo);
-  WriteLn(AMessage);
+  WriteLn(LogTo, AMessage);
 end;
 
 class procedure TUtils.LogSeparator;

--- a/src/main/pascal/PasBuild.Utils.pas
+++ b/src/main/pascal/PasBuild.Utils.pas
@@ -17,7 +17,8 @@ interface
 uses
   Classes, SysUtils, StrUtils, Process,
   PasBuild.Types,
-  PasBuild.Compiler.Backend;
+  PasBuild.Compiler.Backend,
+  PasBuild.Utils.Console;
 
 type
   { Utility functions for file operations and process execution }
@@ -76,6 +77,8 @@ type
     class procedure LogInfo(const AMessage: string);
     class procedure LogError(const AMessage: string);
     class procedure LogWarning(const AMessage: string);
+    class procedure LogTag(const ATag: String; const AMessage: String);
+    class procedure LogTag(const ATag: String; const AMessage: String; var LogTo: Text);
     class procedure LogSeparator;
 
     { Build status tracking }
@@ -526,24 +529,45 @@ end;
 class procedure TUtils.LogInfo(const AMessage: string);
 begin
   if not FQuietMode then
-    WriteLn('[INFO] ', AMessage);
+    LogTag('[INFO]', AMessage);
 end;
 
 class procedure TUtils.LogError(const AMessage: string);
 begin
-  WriteLn(StdErr, '[ERROR] ', AMessage);
+  LogTag('[ERROR]', AMessage, StdErr);
 end;
 
 class procedure TUtils.LogWarning(const AMessage: string);
 begin
   if not FQuietMode then
-    WriteLn('[WARNING] ', AMessage);
+    LogTag('[WARNING]', AMessage);
+end;
+
+class procedure TUtils.LogTag(const ATag: String; const AMessage: String);
+begin
+  LogTag(ATag, AMessage, StdOut);
+end;
+
+class procedure TUtils.LogTag(const ATag: String; const AMessage: String; var LogTo: Text);
+var
+  Color: TSimpleColor;
+begin
+  case ATag of
+    '[INFO]'    : Color := scBlue;
+    '[WARN]'    : Color := scYellow;
+    '[WARNING]' : Color := scYellow;
+    '[ERROR]'   : Color := scRed;
+  else
+    Color := scWhite;
+  end;
+  WriteColor(Color, ATag+' ', LogTo);
+  WriteLn(AMessage);
 end;
 
 class procedure TUtils.LogSeparator;
 begin
   if not FQuietMode then
-    WriteLn('[INFO] ', StringOfChar('-', 72));
+    LogInfo(StringOfChar('-', 72));
 end;
 
 class function TUtils.DirectoryContainsIncludeFiles(const ADirectory: string): Boolean;

--- a/src/main/pascal/PasBuild.pas
+++ b/src/main/pascal/PasBuild.pas
@@ -63,7 +63,8 @@ begin
   TUtils.QuietMode := Args.Goal = bgResolve;
 
   if not TUtils.QuietMode then
-    WriteLn('[INFO] PasBuild ', PASBUILD_VERSION, ' — Born ', PASBUILD_BUILD_DATE, '. Raised by Graeme Geldenhuys.');
+    TUtils.LogInfo('PasBuild ' + PASBUILD_VERSION + ' — Born ' + PASBUILD_BUILD_DATE + '. Raised by Graeme Geldenhuys.');
+
 
   // Resolve compiler executable and instantiate backend via factory.
   // Precedence: --compiler flag > PASBUILD_COMPILER env > PASBUILD_FPC env (deprecated) > 'fpc'

--- a/src/main/pascal/pasbuild.utils.console.pas
+++ b/src/main/pascal/pasbuild.utils.console.pas
@@ -1,0 +1,151 @@
+{
+  This file is part of PasBuild.
+
+  Copyright (c) 2025 Graeme Geldenhuys <graemeg@gmail.com>
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  See LICENSE file in the project root for full license terms.
+}
+
+unit PasBuild.Utils.Console;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils,
+  {$IFDEF WINDOWS}
+  Windows;
+  {$ELSE}
+  TermIO;
+  {$ENDIF}
+
+
+type
+  TSimpleColor = (
+    scResetAll = 0,
+    scBlack = 30,
+    scRed = 31,
+    scGreen = 32,
+    scYellow = 33,
+    scBlue = 34,
+    scMagenta = 35,
+    scCyan = 36,
+    scWhite = 37,
+    scBrightBlack = 90,
+    scBrightRed = 91,
+    scBrightGreen = 92,
+    scBrightYellow = 93,
+    scBrightBlue = 94,
+    scBrightMagenta = 95,
+    scBrightCyan = 96,
+    scBrightWhite = 97
+  );
+
+procedure WriteColor(AColor: TSimpleColor; const AText: String; var AFile: Text);
+
+function  StdOutIsConsole: Boolean;
+
+implementation
+
+{$IFDEF WINDOWS}
+
+var
+  GScreenAttributes: Word;
+  GStdOutIsConsole: Integer = MaxInt;
+
+function AnsiToWinColor(Color: Integer): WORD;
+begin
+  case Color of
+    30: Result := 0;                                 // Black
+    31: Result := FOREGROUND_RED;                    // Red
+    32: Result := FOREGROUND_GREEN;                  // Green
+    33: Result := FOREGROUND_RED or FOREGROUND_GREEN;// Yellow
+    34: Result := FOREGROUND_BLUE;                   // Blue
+    35: Result := FOREGROUND_RED or FOREGROUND_BLUE; // Magenta
+    36: Result := FOREGROUND_GREEN or FOREGROUND_BLUE; // Cyan
+    37: Result := FOREGROUND_RED or FOREGROUND_GREEN or FOREGROUND_BLUE; // White
+
+    90: Result := FOREGROUND_INTENSITY;              // Bright Black (Gray)
+    91: Result := FOREGROUND_RED or FOREGROUND_INTENSITY;
+    92: Result := FOREGROUND_GREEN or FOREGROUND_INTENSITY;
+    93: Result := FOREGROUND_RED or FOREGROUND_GREEN or FOREGROUND_INTENSITY;
+    94: Result := FOREGROUND_BLUE or FOREGROUND_INTENSITY;
+    95: Result := FOREGROUND_RED or FOREGROUND_BLUE or FOREGROUND_INTENSITY;
+    96: Result := FOREGROUND_GREEN or FOREGROUND_BLUE or FOREGROUND_INTENSITY;
+    97: Result := FOREGROUND_RED or FOREGROUND_GREEN or FOREGROUND_BLUE or FOREGROUND_INTENSITY;
+
+    else Result := FOREGROUND_RED or FOREGROUND_GREEN or FOREGROUND_BLUE; // Default (White)
+  end;
+end;
+
+
+procedure WriteColor(AColor: TSimpleColor; const AText: String; var AFile: Text);
+var
+  lColor: Word;
+begin
+  if not StdOutIsConsole then
+  begin
+    Write(AFile, AText);
+    Exit; // no fun stuff for redirected output
+  end;
+  lColor := AnsiToWinColor(Ord(AColor));
+  SetConsoleTextAttribute(StdOutputHandle, lColor);
+  Write(AFile, AText);
+  // restore default
+  SetConsoleTextAttribute(StdOutputHandle, GScreenAttributes);
+end;
+
+function StdOutIsConsole: Boolean;
+var
+  Mode: DWord;
+  lConsoleInfo: TCONSOLESCREENBUFFERINFO;
+begin
+  if  GStdOutIsConsole = MaxInt then
+  begin
+    GStdOutIsConsole := Integer(GetConsoleMode(StdOutputHandle, Mode));
+    // also get the default colors
+    if GStdOutIsConsole <> 0 then
+    begin
+      GetConsoleScreenBufferInfo(StdOutputHandle, lConsoleInfo);
+      GScreenAttributes:=lConsoleInfo.wAttributes;
+    end;
+  end;
+
+  Result := GStdOutIsConsole = 1;
+end;
+
+{$ELSE}
+
+var
+  GStdOutIsConsole: Integer = MaxInt;
+
+procedure WriteColor(AColor: TSimpleColor; const AText: String; var AFile: Text);
+var
+  Col: String;
+const
+  ESC = #27;
+begin
+  Col := IntToStr(Ord(AColor));
+  if StdOutIsConsole then
+      Write(AFile, ESC+'['+Col+'m'+AText +ESC+'[0m')
+    else
+      Write(AFile, AText);
+end;
+
+function StdOutIsConsole: Boolean;
+begin
+  if GStdOutIsConsole = MaxInt then
+  begin
+    GStdOutIsConsole := IsATTY(StdOut);
+  end;
+
+  Result := GStdOutIsConsole <> 0;
+end;
+
+{$ENDIF}
+
+end.
+

--- a/src/test/pascal/PasBuild.Test.Utils.Console.pas
+++ b/src/test/pascal/PasBuild.Test.Utils.Console.pas
@@ -1,0 +1,131 @@
+{
+  This file is part of PasBuild.
+
+  Copyright (c) 2026 Graeme Geldenhuys <graemeg@gmail.com>
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  See LICENSE file in the project root for full license terms.
+}
+
+unit PasBuild.Test.Utils.Console;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpcunit, testregistry,
+  PasBuild.Utils.Console;
+
+type
+
+  { TTestUtilsConsoleWriteColor }
+
+  TTestUtilsConsoleWriteColor = class(TTestCase)
+  private
+    function WriteColorToFakeFile(AColor: TSimpleColor; AText: String): RawByteString;
+  published
+    procedure TestStdOutIsConsole;
+    procedure TestWriteColorRedirected;
+  end;
+
+
+implementation
+
+type
+  PStream = ^TStream;
+
+function GetStream(var F: TTextRec): TStream;
+begin
+  Result := PStream(@F.UserData)^;
+end;
+
+function StreamOpen(var F: TTextRec): Integer;
+begin
+  F.BufPos := 0;
+  F.BufEnd := 0;
+  Result := 0;
+end;
+
+function StreamInOut(var F: TTextRec): Integer;
+begin
+  Result := 0;
+  if F.BufPos > 0 then
+  begin
+    GetStream(F).Write(F.BufPtr^, F.BufPos);
+    F.BufPos := 0;
+  end;
+end;
+
+function StreamFlush(var F: TTextRec): Integer;
+begin
+  Result := StreamInOut(F);
+end;
+
+function StreamClose(var F: TTextRec): Integer;
+begin
+  Result := StreamInOut(F);
+end;
+
+procedure AssignTextToStream(var TF: Text; S: TStream);
+begin
+  with TTextRec(TF) do
+  begin
+    Mode := fmClosed;
+    BufSize := SizeOf(Buffer);
+    BufPtr := @Buffer;
+    OpenFunc := @StreamOpen;
+    InOutFunc := @StreamInOut;
+    FlushFunc := @StreamFlush;
+    CloseFunc := @StreamClose;
+    Name[0] := #0;
+    PStream(@UserData)^ := S;
+  end;
+end;
+
+{ TTestUtilsConsoleWriteColor }
+
+function TTestUtilsConsoleWriteColor.WriteColorToFakeFile(AColor: TSimpleColor; AText: String): RawByteString;
+var
+  F: Text;
+  MS: TStringStream;
+begin
+  Result := '';
+  MS := TStringStream.Create;
+  try
+    AssignTextToStream(F, MS);
+    Rewrite(F);
+    try
+      WriteColor(AColor, AText, F);
+    finally
+      Close(F);
+    end;
+
+    Result := MS.DataString;
+  finally
+    MS.Free;
+  end;
+end;
+
+procedure TTestUtilsConsoleWriteColor.TestWriteColorRedirected;
+var
+  S: RawByteString;
+begin
+  S := WriteColorToFakeFile(scRed, 'NoControlCodes');
+  AssertEquals('Writing to stdout without tty should have no control codes',
+    'NoControlCodes', S);
+end;
+
+procedure TTestUtilsConsoleWriteColor.TestStdOutIsConsole;
+begin
+  AssertEquals('Stdout/Stderr run from test process should not be a console/tty',
+    StdOutIsConsole, False);
+
+end;
+
+initialization
+  RegisterTest(TTestUtilsConsoleWriteColor);
+
+end.
+

--- a/src/test/pascal/TestRunner.pas
+++ b/src/test/pascal/TestRunner.pas
@@ -18,6 +18,7 @@ uses
   PasBuild.Test.Config.MultiModule,
   PasBuild.Test.ModuleDiscovery,
   PasBuild.Test.Utils,
+  PasBuild.Test.Utils.Console,
   PasBuild.Test.Repository,
   PasBuild.Test.Config.Dependencies,
   PasBuild.Test.Dependencies,


### PR DESCRIPTION
Added new unit Pasbuild.Utils.Console. It has two procedures to detect if the process stdout is a console or is being redirected. and another to output text with a color found in the TSimpleColor enum.

It's tested in Windows (via WINE) and Linux. If stdout is a 'real' tty it will output colors. for [INFO]/[WARNING]/[ERROR] messages sent to the console with TUtils.LogInfo etc. 

TUtils.LogTag has also been added where the Tag should be '[TheTag]'. It also has a File parameter to choose between StdOut and StdErr.