### PR TITLE
(TestRunner.pas) Updated TestRunner.pas to work with FPC and Blaise 

### DIFF
--- a/src/main/pascal/PasBuild.Command.Init.pas
+++ b/src/main/pascal/PasBuild.Command.Init.pas
@@ -160,10 +160,15 @@ function TInitCommand.GenerateTestRunnerPas(const AProjectName: string): string;
 begin
   Result := 'program TestRunner;' + LineEnding +
             '' + LineEnding +
+            '{$IFDEF FPC}' + LineEnding +
             '{$mode objfpc}{$H+}' + LineEnding +
-            '' + LineEnding +
             'uses' + LineEnding +
             '  Classes, SysUtils, fpcunit, testregistry, consoletestrunner;' + LineEnding +
+            '{$ENDIF}' + LineEnding +
+            '' + LineEnding +
+            '{$IFDEF BLAISE}' + LineEnding +
+            'uses blaise.testing, blaise.testing.runner.text;' + LineEnding +
+            '{$ENDIF}' + LineEnding +
             '' + LineEnding +
             'type' + LineEnding +
             '  { Sample test case - replace with your actual tests }' + LineEnding +
@@ -177,6 +182,7 @@ begin
             '  AssertEquals(''Sample test'', 2, 1 + 1);' + LineEnding +
             'end;' + LineEnding +
             '' + LineEnding +
+            '{$IFDEF FPC}' + LineEnding +
             'var' + LineEnding +
             '  Application: TTestRunner;' + LineEnding +
             '' + LineEnding +
@@ -189,7 +195,16 @@ begin
             '  finally' + LineEnding +
             '    Application.Free;' + LineEnding +
             '  end;' + LineEnding +
-            'end.' + LineEnding;
+            'end.' + LineEnding +
+            '{$ENDIF}' + LineEnding +
+            '' + LineEnding +
+            '{$IFDEF BLAISE}' + LineEnding +
+            'begin' + LineEnding +
+            '  RegisterTest(TSampleTest);  ' + LineEnding +
+            '  Halt(RunAll());' + LineEnding +
+            'end.' + LineEnding +
+            '{$ENDIF}' + LineEnding +
+            '' + LineEnding;
 end;
 
 function TInitCommand.GenerateLicenseFile(const ALicense: string): string;


### PR DESCRIPTION
The `TestRunner.pas` file has been updated to work with FPC and Blaise compiler. This is what the new `TestRunner.pas` looks like : 

```pascal
program TestRunner;

{$IFDEF FPC}
{$mode objfpc}{$H+}
uses
  Classes, SysUtils, fpcunit, testregistry, consoletestrunner;
{$ENDIF}

{$IFDEF BLAISE}
uses blaise.testing, blaise.testing.runner.text;
{$ENDIF}

type
  { Sample test case - replace with your actual tests }
  TSampleTest = class(TTestCase)
  published
    procedure TestExample;
  end;

procedure TSampleTest.TestExample;
begin
  AssertEquals('Sample test', 2, 1 + 1);
end;

{$IFDEF FPC}
var
  Application: TTestRunner;

begin
  Application := TTestRunner.Create(nil);
  try
    RegisterTest(TSampleTest);
    Application.Initialize;
    Application.Run;
  finally
    Application.Free;
  end;
end.
{$ENDIF}

{$IFDEF BLAISE}
begin
  RegisterTest(TSampleTest);  
  Halt(RunAll());
end.
{$ENDIF}
```
`pasbuild test` and `pasbuild compile` were run on the PasBuild source as well as a simple `pasbuild init` project.  All is working.
