### PR TITLE
Add support for SOURCE_DATE_EPOCH

### DIFF
--- a/src/main/pascal/PasBuild.Command.ProcessResources.pas
+++ b/src/main/pascal/PasBuild.Command.ProcessResources.pas
@@ -58,10 +58,10 @@ end;
 
 function TProcessResourcesCommand.ApplyFiltering(const AContent: string): string;
 var
-  Now: TDateTime;
+  BuildDateTime: TDateTime;
 begin
   Result := AContent;
-  Now := SysUtils.Now;
+  BuildDateTime := TUtils.GetBuildDateTime();
 
   // Replace project variables
   Result := StringReplace(Result, '${project.name}', Config.Name, [rfReplaceAll]);
@@ -70,9 +70,9 @@ begin
   Result := StringReplace(Result, '${project.license}', Config.License, [rfReplaceAll]);
 
   // Replace build-time variables (ISO-8601 format)
-  Result := StringReplace(Result, '${build.date}', FormatDateTime('yyyy-mm-dd', Now), [rfReplaceAll]);
-  Result := StringReplace(Result, '${build.time}', FormatDateTime('hh:nn:ss', Now), [rfReplaceAll]);
-  Result := StringReplace(Result, '${build.timestamp}', FormatDateTime('yyyy-mm-dd''T''hh:nn:ss', Now), [rfReplaceAll]);
+  Result := StringReplace(Result, '${build.date}', FormatDateTime('yyyy-mm-dd', BuildDateTime), [rfReplaceAll]);
+  Result := StringReplace(Result, '${build.time}', FormatDateTime('hh:nn:ss', BuildDateTime), [rfReplaceAll]);
+  Result := StringReplace(Result, '${build.timestamp}', FormatDateTime('yyyy-mm-dd''T''hh:nn:ss', BuildDateTime), [rfReplaceAll]);
 end;
 
 function TProcessResourcesCommand.ProcessFile(const ASourceFile, ARelativePath: string): Boolean;

--- a/src/main/pascal/PasBuild.Command.ProcessTestResources.pas
+++ b/src/main/pascal/PasBuild.Command.ProcessTestResources.pas
@@ -58,10 +58,10 @@ end;
 
 function TProcessTestResourcesCommand.ApplyFiltering(const AContent: string): string;
 var
-  Now: TDateTime;
+  BuildDateTime: TDateTime;
 begin
   Result := AContent;
-  Now := SysUtils.Now;
+  BuildDateTime := TUtils.GetBuildDateTime();
 
   // Replace project variables
   Result := StringReplace(Result, '${project.name}', Config.Name, [rfReplaceAll]);
@@ -70,9 +70,9 @@ begin
   Result := StringReplace(Result, '${project.license}', Config.License, [rfReplaceAll]);
 
   // Replace build-time variables (ISO-8601 format)
-  Result := StringReplace(Result, '${build.date}', FormatDateTime('yyyy-mm-dd', Now), [rfReplaceAll]);
-  Result := StringReplace(Result, '${build.time}', FormatDateTime('hh:nn:ss', Now), [rfReplaceAll]);
-  Result := StringReplace(Result, '${build.timestamp}', FormatDateTime('yyyy-mm-dd''T''hh:nn:ss', Now), [rfReplaceAll]);
+  Result := StringReplace(Result, '${build.date}', FormatDateTime('yyyy-mm-dd', BuildDateTime), [rfReplaceAll]);
+  Result := StringReplace(Result, '${build.time}', FormatDateTime('hh:nn:ss', BuildDateTime), [rfReplaceAll]);
+  Result := StringReplace(Result, '${build.timestamp}', FormatDateTime('yyyy-mm-dd''T''hh:nn:ss', BuildDateTime), [rfReplaceAll]);
 end;
 
 function TProcessTestResourcesCommand.ProcessFile(const ASourceFile, ARelativePath: string): Boolean;

--- a/src/main/pascal/PasBuild.Utils.pas
+++ b/src/main/pascal/PasBuild.Utils.pas
@@ -86,9 +86,15 @@ type
     class function CollectSourceFiles(const ABaseDir: string): TStringList;
     class function CollectIncludeFiles(const ABaseDir: string): TStringList;
     class procedure WriteListFile(const AFilePath: string; AList: TStringList);
+
+    { Build date utilities }
+    class function GetBuildDateTime(): TDateTime;
   end;
 
 implementation
+
+uses
+  DateUtils;
 
 { Forward declaration for recursive helper }
 procedure RecursiveScanDirs(const ADir: string; AList: TStringList); forward;
@@ -887,6 +893,17 @@ begin
     on E: Exception do
       LogWarning('Failed to write list file ' + AFilePath + ': ' + E.Message);
   end;
+end;
+
+class function TUtils.GetBuildDateTime(): TDateTime;
+var
+  SourceDateEpoch: string;
+begin
+  SourceDateEpoch := GetEnvironmentVariable('SOURCE_DATE_EPOCH');
+  if Length(SourceDateEpoch) > 0 then
+    Result := UnixToDateTime(StrToInt64(SourceDateEpoch))
+  else
+    Result := SysUtils.Now()
 end;
 
 end.


### PR DESCRIPTION
If the `SOURCE_DATE_EPOCH` environment variable is set, its value will be used instead of the current date/time when inserting build date info. See: https://reproducible-builds.org/docs/source-date-epoch/

Solves issue #20.